### PR TITLE
don't extend greater and geq

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Infinities"
 uuid = "e1ba4f0e-776d-440f-acd9-e1d2e9742647"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [compat]
 julia = "1"

--- a/src/Infinities.jl
+++ b/src/Infinities.jl
@@ -311,7 +311,7 @@ isless(x::ComplexInfinity{Bool}, y::Number) = x.signbit && y ≠ -∞
 -(y::ComplexInfinity{B}) where B<:Integer = sign(y) == 1 ? ComplexInfinity(one(B)) : ComplexInfinity(zero(B))
 
 function +(x::ComplexInfinity, y::ComplexInfinity)
-    x == y || throw(ArgumentError("Angles must be the same to add ∞"))
+    x == y || throw(ArgumentError("Angles must be the same to add ∞"))
     promote_type(typeof(x),typeof(y))(x.signbit)
 end
 
@@ -374,13 +374,6 @@ for OP in (:<,:≤)
     @eval begin
         $OP(x::Real, y::ComplexInfinity{B}) where B<:Integer = sign(y) ==  1
         $OP(y::ComplexInfinity{B}, x::Real) where B<:Integer = sign(y) == -1
-    end
-end
-
-for OP in (:≥,)
-    @eval begin
-        $OP(x::Real, y::ComplexInfinity{B}) where B<:Integer = sign(y) == -1
-        $OP(y::ComplexInfinity{B}, x::Real) where B<:Integer = sign(y) == 1
     end
 end
 

--- a/src/Infinities.jl
+++ b/src/Infinities.jl
@@ -61,19 +61,11 @@ isless(x::Infinity, y::Real) = false
 
 ≤(::Infinity, ::Infinity) = true
 <(::Infinity, ::Infinity) = false
-≥(::Infinity, ::Infinity) = true
->(::Infinity, ::Infinity) = false
 
 <(x::Real, ::Infinity) = isfinite(x) || signbit(x)
 ≤(::Real, ::Infinity) = true
 <(::Infinity, ::Real) = false
 ≤(::Infinity, y::Real) = isinf(y) && !signbit(y)
-
->(::Real, ::Infinity) = false
-≥(x::Real, ::Infinity) = isinf(x) && !signbit(x)
->(::Infinity, y::Real) = isfinite(y) || signbit(y)
-≥(::Infinity, y::Real) = true
-
 
 min(::Infinity, ::Infinity) = ∞
 max(::Infinity, ::Infinity) = ∞
@@ -191,10 +183,6 @@ end
 ≤(::Infinity, s::RealInfinity) = !signbit(s)
 <(s::RealInfinity, ::Infinity) = signbit(s)
 <(::Infinity, ::RealInfinity) = false
-≥(s::RealInfinity, ::Infinity) = !signbit(s)
-≥(::Infinity, ::RealInfinity) = true
->(::RealInfinity, ::Infinity) = false
->(::Infinity, s::RealInfinity) = signbit(s)
 
 
 
@@ -389,7 +377,7 @@ for OP in (:<,:≤)
     end
 end
 
-for OP in (:>, :≥)
+for OP in (:≥,)
     @eval begin
         $OP(x::Real, y::ComplexInfinity{B}) where B<:Integer = sign(y) == -1
         $OP(y::ComplexInfinity{B}, x::Real) where B<:Integer = sign(y) == 1

--- a/src/cardinality.jl
+++ b/src/cardinality.jl
@@ -67,12 +67,8 @@ isless(x::InfiniteCardinal, y::AbstractFloat) = false
 
 @generated <(::InfiniteCardinal{N}, ::InfiniteCardinal{M}) where {N,M} = :($(N < M))
 @generated ≤(::InfiniteCardinal{N}, ::InfiniteCardinal{M}) where {N,M} = :($(N ≤ M))
-@generated >(::InfiniteCardinal{N}, ::InfiniteCardinal{M}) where {N,M} = :($(N > M))
-@generated ≥(::InfiniteCardinal{N}, ::InfiniteCardinal{M}) where {N,M} = :($(N ≥ M))
 
 ≤(::InfiniteCardinal{0}, ::InfiniteCardinal) = true
->(::InfiniteCardinal{0}, ::InfiniteCardinal) = false
-≥(::InfiniteCardinal, ::InfiniteCardinal{0}) = true
 <(::InfiniteCardinal, ::InfiniteCardinal{0}) = false
 
 
@@ -82,14 +78,9 @@ isless(x::InfiniteCardinal, y::AbstractFloat) = false
 <(::InfiniteCardinal, x::Real) = false
 ≤(::InfiniteCardinal{0}, x::Real) = ∞ ≤ x
 ≤(::InfiniteCardinal, x::Real) = false
-≤(::InfiniteCardinal{0}, x::RealInfinity) = ∞ ≤ x
+≤(::InfiniteCardinal{0}, x::RealInfinity) = ∞ ≤ x
 ≤(::InfiniteCardinal, x::RealInfinity) = false
->(::InfiniteCardinal{0}, y::Real) = ∞ > y
->(::InfiniteCardinal, ::Real) = true
-≥(::InfiniteCardinal, ::Real) = true
->(::Real, ::InfiniteCardinal) = false
-≥(x::Real, ::InfiniteCardinal{0}) = x ≥ ∞
-≥(x::Real, ::InfiniteCardinal) = false
+<(::InfiniteCardinal, x::RealInfinity) = false
 
 
 <(::Infinity, ::InfiniteCardinal{0}) = false
@@ -98,20 +89,11 @@ isless(x::InfiniteCardinal, y::AbstractFloat) = false
 <(::InfiniteCardinal, ::Infinity) = false
 ≤(::InfiniteCardinal{0}, ::Infinity) = true
 ≤(::InfiniteCardinal, ::Infinity) = false
->(::InfiniteCardinal{0}, ::Infinity) = false
->(::InfiniteCardinal, ::Infinity) = true
-≥(::InfiniteCardinal, ::Infinity) = true
->(::Infinity, ::InfiniteCardinal) = false
-≥(::Infinity, ::InfiniteCardinal{0}) = true
-≥(::Infinity, ::InfiniteCardinal) = false
 
 
 <(x::RealInfinity, ::InfiniteCardinal{0}) = x < ∞
 <(x::RealInfinity, ::InfiniteCardinal) = true
 ≤(x::RealInfinity, ::InfiniteCardinal) = true
->(::InfiniteCardinal{0}, y::RealInfinity) = ∞ > y
->(::InfiniteCardinal, ::RealInfinity) = true
-≥(::InfiniteCardinal, ::RealInfinity) = true
 
 
 @generated min(::InfiniteCardinal{N}, ::InfiniteCardinal{M}) where {N,M} = :(InfiniteCardinal{$(min(N,M))}())


### PR DESCRIPTION
On master:
```julia
julia> using SnoopCompileCore

julia> invalidations = @snoopr using Infinities;

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
4-element Vector{SnoopCompile.MethodInvalidations}:
 inserting getindex(A::Array, i1::InfiniteCardinal{0}, I::Integer...) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:217 invalidated:
   backedges: 1: superseding getindex(A::Array, i1::Integer, I::Integer...) @ Base abstractarray.jl:1268 with MethodInstance for getindex(::Vector{Tuple{Float64, Float64}}, ::Integer) (1 children)
              2: superseding getindex(A::Array, i1::Integer, I::Integer...) @ Base abstractarray.jl:1268 with MethodInstance for getindex(::Vector{Int64}, ::Integer) (1 children)
              3: superseding getindex(A::Array, i1::Integer, I::Integer...) @ Base abstractarray.jl:1268 with MethodInstance for getindex(::Vector{Base.StackTraces.StackFrame}, ::Integer) (1 children)
              4: superseding getindex(A::Array, i1::Integer, I::Integer...) @ Base abstractarray.jl:1268 with MethodInstance for getindex(::Vector{Float64}, ::Integer) (2 children)
   35 mt_cache

 inserting to_index(::Union{InfiniteCardinal{0}, Infinities.Infinity}) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:190 invalidated:
   backedges: 1: superseding to_index(i::Integer) @ Base indices.jl:292 with MethodInstance for Base.to_index(::Integer) (29 children)

 inserting to_shape(::Union{InfiniteCardinal{0}, Infinities.Infinity}) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:191 invalidated:
   backedges: 1: superseding to_shape(i::Integer) @ Base abstractarray.jl:825 with MethodInstance for Base.to_shape(::Integer) (38 children)

 inserting >(::Infinities.Infinity, s::RealInfinity) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/Infinities.jl:197 invalidated:
   backedges: 1: superseding >(x, y) @ Base operators.jl:369 with MethodInstance for >(::Any, ::Any) (1065 children)
```

This PR removes the invalidation of `>` entirely. In any case, the docstring of `>` states that
```julia
>(x, y)

  Greater-than comparison operator. Falls back to y < x.

  Implementation
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  Generally, new types should implement < instead of this function, and rely on the fallback definition >(x, y) = y < x.
```

and the docstring of `\geq` states
```julia
>=(x, y)
  ≥(x,y)

  Greater-than-or-equals comparison operator. Falls back to y <= x.
```

Therefore, we only need to define these one way, for the lesser than comparison. Results, such as the following, are constant-propagated even without these:
```julia
julia> a = InfiniteCardinal{0}()
ℵ₀

julia> b = InfiniteCardinal{1}()
ℵ₁

julia> @code_typed a >= b
CodeInfo(
1 ─     return false
) => Bool
```