### PR TITLE
remove unbound type parameters

### DIFF
--- a/src/cardinality.jl
+++ b/src/cardinality.jl
@@ -16,8 +16,8 @@ const ℵ₁ = InfiniteCardinal{1}()
 string(::InfiniteCardinal{0}) = "ℵ₀"
 string(::InfiniteCardinal{1}) = "ℵ₁"
 
-show(io::IO, F::InfiniteCardinal{0}) where N = print(io, "ℵ₀")
-show(io::IO, F::InfiniteCardinal{1}) where N = print(io, "ℵ₁")
+show(io::IO, F::InfiniteCardinal{0}) = print(io, "ℵ₀")
+show(io::IO, F::InfiniteCardinal{1}) = print(io, "ℵ₁")
 
 
 isone(::InfiniteCardinal) = false


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this may not be merely cosmetic.