### PR TITLE
don't specialize `convert`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Infinities"
 uuid = "e1ba4f0e-776d-440f-acd9-e1d2e9742647"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [compat]
 julia = "1"

--- a/src/Infinities.jl
+++ b/src/Infinities.jl
@@ -28,14 +28,11 @@ const ∞ = Infinity()
 show(io::IO, ::Infinity) = print(io, "∞")
 string(::Infinity) = "∞"
 
-convert(::Type{Float64}, ::Infinity) = Inf64
-convert(::Type{Float32}, ::Infinity) = Inf32
-convert(::Type{Float16}, ::Infinity) = Inf16
-Base.Float64(::Infinity) = convert(Float64, ∞)
-Base.Float32(::Infinity) = convert(Float32, ∞)
-Base.Float16(::Infinity) = convert(Float16, ∞)
-Base.BigFloat(::Infinity) = BigFloat(Inf)
-convert(::Type{AF}, ::Infinity) where AF<:AbstractFloat = convert(AF, Inf)
+_convert(::Type{Float64}, ::Infinity) = Inf64
+_convert(::Type{Float32}, ::Infinity) = Inf32
+_convert(::Type{Float16}, ::Infinity) = Inf16
+_convert(::Type{T}, ::Infinity) where {T<:Real} = convert(T, Inf)::T
+(::Type{T})(x::Infinity) where {T<:Real} = _convert(T, x)
 
 
 sign(y::Infinity) = 1
@@ -131,16 +128,13 @@ isinf(::RealInfinity) = true
 isfinite(::RealInfinity) = false
 
 promote_rule(::Type{Infinity}, ::Type{RealInfinity}) = RealInfinity
-convert(::Type{RealInfinity}, ::Infinity) = RealInfinity(false)
+_convert(::Type{RealInfinity}, ::Infinity) = RealInfinity(false)
 
-convert(::Type{Float64}, x::RealInfinity) = sign(x)*Inf64
-convert(::Type{Float32}, x::RealInfinity) = sign(x)*Inf32
-convert(::Type{Float16}, x::RealInfinity) = sign(x)*Inf16
-Base.Float64(x::RealInfinity) = convert(Float64, x)
-Base.Float32(x::RealInfinity) = convert(Float32, x)
-Base.Float16(x::RealInfinity) = convert(Float16, x)
-Base.BigFloat(x::RealInfinity) = sign(x)*BigFloat(Inf)
-convert(::Type{AF}, x::RealInfinity) where AF<:AbstractFloat = sign(x)*convert(AF, Inf)
+_convert(::Type{Float16}, x::RealInfinity) = sign(x)*Inf16
+_convert(::Type{Float32}, x::RealInfinity) = sign(x)*Inf32
+_convert(::Type{Float64}, x::RealInfinity) = sign(x)*Inf64
+_convert(::Type{T}, x::RealInfinity) where {T<:Real} = sign(x)*convert(T, Inf)
+(::Type{T})(x::RealInfinity) where {T<:Real} = _convert(T, x)
 
 
 signbit(y::RealInfinity) = y.signbit

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,8 @@ import Infinities: Infinity
             @test convert(Float32, ∞) ≡ Float32(∞) ≡ Inf32
             @test convert(Float16, ∞) ≡ Float16(∞) ≡ Inf16
             @test convert(BigFloat, ∞)::BigFloat == BigFloat(∞)::BigFloat == BigFloat(Inf)
+            @test convert(RealInfinity, ∞) isa RealInfinity
+            @test convert(RealInfinity, ∞) == Inf
         end
     end
 


### PR DESCRIPTION
This reduces invalidation without changing functionality. On master, and using julia nightly,
```julia
julia> VERSION
v"1.9.0-DEV.1570"

julia> using SnoopCompileCore

julia> invalidations = @snoopr using Infinities;

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
6-element Vector{SnoopCompile.MethodInvalidations}:
 inserting one(::Type{<:InfiniteCardinal}) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:31 invalidated:
   backedges: 1: superseding one(::Type{T}) where T<:Number @ Base number.jl:346 with MethodInstance for one(::Type{T} where T<:Integer) (1 children)

 inserting zero(::InfiniteCardinal) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:30 invalidated:
   backedges: 1: superseding zero(x::Number) @ Base number.jl:308 with MethodInstance for zero(::Integer) (2 children)

 inserting getindex(A::Array, i1::InfiniteCardinal{0}, I::Integer...) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:199 invalidated:
   backedges: 1: superseding getindex(A::Array, i1::Integer, I::Integer...) @ Base abstractarray.jl:1289 with MethodInstance for getindex(::Vector{Revise.FileInfo}, ::Integer) (5 children)

 inserting to_index(::Union{InfiniteCardinal{0}, Infinities.Infinity}) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:172 invalidated:
   backedges: 1: superseding to_index(i::Integer) @ Base indices.jl:292 with MethodInstance for Base.to_index(::Integer) (5 children)

 inserting convert(::Type{Float32}, x::RealInfinity) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/Infinities.jl:137 invalidated:
   backedges: 1: superseding convert(::Type{T}, x::Number) where T<:Number @ Base number.jl:7 with MethodInstance for convert(::Type{<:Real}, ::Real) (11 children)

 inserting to_shape(::Union{InfiniteCardinal{0}, Infinities.Infinity}) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:173 invalidated:
   backedges: 1: superseding to_shape(i::Integer) @ Base abstractarray.jl:846 with MethodInstance for Base.to_shape(::Integer) (25 children)
```
This PR
```julia
julia> trees = invalidation_trees(invalidations)
4-element Vector{SnoopCompile.MethodInvalidations}:
 inserting one(::Type{<:InfiniteCardinal}) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:31 invalidated:
   backedges: 1: superseding one(::Type{T}) where T<:Number @ Base number.jl:346 with MethodInstance for one(::Type{T} where T<:Integer) (1 children)

 inserting zero(::InfiniteCardinal) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:30 invalidated:
   backedges: 1: superseding zero(x::Number) @ Base number.jl:308 with MethodInstance for zero(::Integer) (2 children)

 inserting to_index(::Union{InfiniteCardinal{0}, Infinities.Infinity}) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:172 invalidated:
   backedges: 1: superseding to_index(i::Integer) @ Base indices.jl:292 with MethodInstance for Base.to_index(::Integer) (10 children)

 inserting to_shape(::Union{InfiniteCardinal{0}, Infinities.Infinity}) @ Infinities ~/Dropbox/JuliaPackages/Infinities.jl/src/cardinality.jl:173 invalidated:
   backedges: 1: superseding to_shape(i::Integer) @ Base abstractarray.jl:846 with MethodInstance for Base.to_shape(::Integer) (25 children)
   41 mt_cache
```
This PR removes the invalidation due to `convert`, and I'm not certain how the `getindex` one is resolved as well. In any case, specializing `convert` seems unnecessary, as `convert` calls constructors that are specialized anyway.