### PR TITLE
Comparisons of `InfiniteCardinal` with `BigInt`/`BigFloat`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Infinities"
 uuid = "e1ba4f0e-776d-440f-acd9-e1d2e9742647"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [compat]
 Aqua = "0.6"

--- a/src/cardinality.jl
+++ b/src/cardinality.jl
@@ -57,6 +57,11 @@ end
 ==(::InfiniteCardinal, y::Real) = ∞ == y
 ==(x::Real, ::InfiniteCardinal) = x == ∞
 
+==(::BigInt, ::InfiniteCardinal) = false
+==(::InfiniteCardinal, ::BigInt) = false
+==(x::BigFloat, ::InfiniteCardinal) = x == ∞
+==(::InfiniteCardinal, x::BigFloat) = x == ∞
+
 @generated isless(::InfiniteCardinal{N}, ::InfiniteCardinal{M}) where {N,M} = :($(isless(N, M)))
 isless(::InfiniteCardinal{0}, ::InfiniteCardinal{0}) = false
 isless(x::Real, ::InfiniteCardinal{0}) = isfinite(x)
@@ -83,6 +88,18 @@ isless(x::InfiniteCardinal, y::AbstractFloat) = false
 ≤(::InfiniteCardinal, x::RealInfinity) = false
 <(::InfiniteCardinal, x::RealInfinity) = false
 
+for T in (:InfiniteCardinal, :(InfiniteCardinal{0}))
+    @eval begin
+        ≤(::BigInt, ::$T) = true
+        <(::BigInt, ::$T) = true
+        ≤(::$T, ::BigInt) = false
+        <(::$T, ::BigInt) = false
+        ≤(x::BigFloat, ::$T) = true
+        <(x::BigFloat, ::$T) = x < ∞
+        ≤(::$T, x::BigFloat) = ∞ ≤ x
+        <(::$T, x::BigFloat) = false
+    end
+end
 
 <(::Infinity, ::InfiniteCardinal{0}) = false
 <(::Infinity, ::InfiniteCardinal) = true

--- a/test/test_cardinality.jl
+++ b/test/test_cardinality.jl
@@ -82,7 +82,14 @@ using Infinities, Base64, Base.Checked, Test
                 @test x <= InfiniteCardinal{1}()
                 @test !(InfiniteCardinal{1}() <= x)
             end
+            @test (ℵ₀ == big(Inf)) == (ℵ₀ == Inf)
+            @test (big(Inf) == ℵ₀) == (Inf == ℵ₀)
+            @test (ℵ₀ < big(Inf)) == (ℵ₀ < Inf)
+            @test (big(Inf) < ℵ₀) == (Inf < ℵ₀)
+            @test (ℵ₀ <= big(Inf)) == (ℵ₀ <= Inf)
+            @test (big(Inf) <= ℵ₀) == (Inf <= ℵ₀)
         end
+
     end
 
     @testset "min/max" begin

--- a/test/test_cardinality.jl
+++ b/test/test_cardinality.jl
@@ -68,6 +68,21 @@ using Infinities, Base64, Base.Checked, Test
         @test !(ℵ₀ < 5) && !(ℵ₀ ≤ 5)
         @test ℵ₀ > 5 && ℵ₀ ≥ 5
         @test !(5 > ℵ₀) && !(5 ≥ ℵ₀)
+
+        @testset "BigInt/BigFloat" begin
+            for x in (big(2), big(2.0))
+                @test !(x == ℵ₀)
+                @test !(ℵ₀ == x)
+                @test x < ℵ₀
+                @test !(ℵ₀ < x)
+                @test x <= ℵ₀
+                @test !(ℵ₀ <= x)
+                @test x < InfiniteCardinal{1}()
+                @test !(InfiniteCardinal{1}() < x)
+                @test x <= InfiniteCardinal{1}()
+                @test !(InfiniteCardinal{1}() <= x)
+            end
+        end
     end
 
     @testset "min/max" begin


### PR DESCRIPTION
These need to be special cased to avoid ambiguities.