### PR TITLE
Change explicit test on v1.9 to v1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         version:
           - '1.0'
           - '1'
-          - '^1.9.0-0'
+          - '~1.10.0-0'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
Now that v1 points to v1.9, an explicit test on v1.9 is unnecessary