### PR TITLE
to_index for RealInfinity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Infinities"
 uuid = "e1ba4f0e-776d-440f-acd9-e1d2e9742647"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.1.8"
+version = "0.1.9"
 
 [compat]
 Aqua = "0.8"

--- a/src/Infinities.jl
+++ b/src/Infinities.jl
@@ -243,7 +243,7 @@ max(::RealInfinity, ::Infinity) = ∞
 min(::Infinity, x::RealInfinity) = x
 max(::Infinity, x::RealInfinity) = ∞
 
-
+Base.to_index(i::RealInfinity) = convert(Integer, i)
 
 ######
 # ComplexInfinity

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -205,6 +205,8 @@ end
             @test convert(Float16, -∞) ≡ Float16(-∞) ≡ -Inf16
             @test convert(BigFloat, -∞)::BigFloat == BigFloat(-∞)::BigFloat == -BigFloat(Inf)
         end
+
+        @test Base.to_index(RealInfinity()) ≡ ℵ₀
     end
 
     @testset "ComplexInfinity" begin


### PR DESCRIPTION
Since `RealInfinity` is being used as an index in https://github.com/JuliaArrays/InfiniteArrays.jl/blob/e323a66574662ae4b171cd8fc6822ad79e27ea8c/src/infarrays.jl#L119-L120, it makes sense to define `to_index` for it instead of extending `getindex`.