### PR TITLE
Explicitly import `Bool` and `Integer` before extending these

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Infinities"
 uuid = "e1ba4f0e-776d-440f-acd9-e1d2e9742647"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.1.10"
+version = "0.1.11"
 
 [compat]
 Aqua = "0.8"

--- a/src/Infinities.jl
+++ b/src/Infinities.jl
@@ -2,7 +2,8 @@ module Infinities
 
 import Base: angle, isone, iszero, isinf, isfinite, abs, one, oneunit, zero, isless, inv,
                 +, -, *, ==, <, ≤, >, ≥, fld, cld, div, mod, min, max, sign, signbit,
-                string, show, promote_rule, convert, getindex
+                string, show, promote_rule, convert, getindex,
+                Bool, Integer
 
 export ∞,  ℵ₀,  ℵ₁, RealInfinity, ComplexInfinity, InfiniteCardinal, NotANumber
 # The following is commented out for now to avoid conflicts with Infinity.jl


### PR DESCRIPTION
These `Base` functions were being extended in the package, but they were not imported