### PR TITLE
Avoid warnings with Julia 1.13

### DIFF
--- a/src/Infinities.jl
+++ b/src/Infinities.jl
@@ -65,7 +65,7 @@ _convert(::Type{T}, x::RealInfinity) where {T<:Real} = sign(x)*convert(T, Inf)
 (::Type{T})(x::RealInfinity) where {T<:Real} = _convert(T, x)
 
 for Typ in (RealInfinity, Infinity)
-    @eval Bool(x::$Typ) = throw(InexactError(:Bool, Bool, x)) # ambiguity fix
+    @eval Base.Bool(x::$Typ) = throw(InexactError(:Bool, Bool, x)) # ambiguity fix
 end
 
 sign(y::RealInfinity) = 1-2signbit(y)

--- a/src/cardinality.jl
+++ b/src/cardinality.jl
@@ -31,12 +31,12 @@ one(::Type{<:InfiniteCardinal}) = 1
 oneunit(::Type{<:InfiniteCardinal}) = 1
 oneunit(::InfiniteCardinal) = 1
 
-Integer(::Infinity) = InfiniteCardinal{0}()
-function Integer(x::RealInfinity)
+Base.Integer(::Infinity) = InfiniteCardinal{0}()
+function Base.Integer(x::RealInfinity)
     signbit(x) && throw(InexactError(:Integer, Integer, x))
     ℵ₀
 end
-function Integer(x::ComplexInfinity)
+function Base.Integer(x::ComplexInfinity)
     iszero(angle(x)) || throw(InexactError(:Integer, Integer, x))
     ℵ₀
 end


### PR DESCRIPTION
Constructors seem to always need a FQN even when `import`ed.