### PR TITLE
`promote` of mixed-sign infinities returns values of two different types

### DIFF
--- a/src/Infinities.jl
+++ b/src/Infinities.jl
@@ -57,6 +57,7 @@ RealInfinity() = PositiveInfinity()
 RealInfinity(::Infinity) = PositiveInfinity()
 RealInfinity(x::RealInfinity) = x
 RealInfinity(x::Bool) = ifelse(x, NegativeInfinity(), PositiveInfinity())
+PositiveInfinity(::Infinity) = PositiveInfinity() # otherwise the generic `(::Type{T})(::Infinity) where T<:Real` would route through `Inf`
 
 _convert(::Type{Float16}, x::RealInfinity) = sign(x)*Inf16
 _convert(::Type{Float32}, x::RealInfinity) = sign(x)*Inf32

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -7,7 +7,8 @@ iszero(::AllInfinities) = false
 isinf(::AllInfinities) = true
 isfinite(::AllInfinities) = false
 
-promote_rule(::Type{Infinity}, ::Type{<:RealInfinity}) = RealInfinity # not detected by CodeCov. Removing this results in failed tests.
+# `Infinity` is positive, so it has no common type with `NegativeInfinity` (as is already the case for `PositiveInfinity`).
+promote_rule(::Type{Infinity}, ::Type{PositiveInfinity}) = PositiveInfinity
 promote_rule(::Type{Infinity}, ::Type{ComplexInfinity{T}}) where T = ComplexInfinity{T}
 promote_rule(::Type{<:RealInfinity}, ::Type{ComplexInfinity{T}}) where T = ComplexInfinity{T}
 promote_rule(::Type{ComplexInfinity{T}}, ::Type{<:RealInfinity}) where T<:Integer = ComplexInfinity{T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,8 +97,11 @@ using Aqua
         @test RealInfinity(∞) ≡ convert(RealInfinity, ∞) ≡ RealInfinity() ≡
                 RealInfinity(false) ≡ RealInfinity(RealInfinity())
 
-        @test promote_type(Infinity, RealInfinity) == RealInfinity
+        @test promote_type(Infinity, PositiveInfinity) == PositiveInfinity
         @test promote(∞, RealInfinity()) ≡ (RealInfinity(),RealInfinity())
+        # ∞ and -∞ have no common concrete type, just like +∞ and -∞
+        @test_throws ErrorException promote(∞, -∞)
+        @test_throws ErrorException promote(+∞, -∞)
 
         @test -∞ ≡ RealInfinity(true)
         @test +∞ ≡ RealInfinity()
@@ -203,7 +206,8 @@ using Aqua
         @test isinf(-∞)
         @test !isfinite(-∞)
 
-        @test [∞, -∞] isa Vector{RealInfinity}
+        @test [∞, -∞] isa Vector{Real}
+        @test [+∞, -∞] isa Vector{RealInfinity}
 
         @test mod(-∞, 5) isa NotANumber
         @test mod(-∞, -∞) isa NotANumber


### PR DESCRIPTION
`promote` should return its arguments converted to a *common* type, but promoting `∞` with `-∞` returns one `PositiveInfinity` and one `NegativeInfinity`:

```julia
julia> using Infinities

julia> promote(∞, -∞)
(+∞, -∞)

julia> typeof.(promote(∞, -∞))
(PositiveInfinity, NegativeInfinity)
```

The cause is that the promotion target is abstract:

```julia
julia> promote_type(Infinities.Infinity, NegativeInfinity)
RealInfinity

julia> isconcretetype(promote_type(Infinities.Infinity, NegativeInfinity))
false
```

from `src/interface.jl:10`:

```julia
promote_rule(::Type{Infinity}, ::Type{<:RealInfinity}) = RealInfinity
```

Promotion with the same signedness works correctly.

Fix this by only promoting what we can promote, but not more (which is less than before, but only what should be correct).