### PR TITLE
Fix `hash`: define the two-argument `hash(x, ::UInt)`

### DIFF
--- a/src/Infinities.jl
+++ b/src/Infinities.jl
@@ -129,7 +129,21 @@ oneunit(::ComplexInfinity) = oneunit(ComplexF64)
 zero(::ComplexInfinity) = zero(ComplexF64)
 zero(::Type{<:ComplexInfinity}) = zero(ComplexF64)
 
-Base.hash(::Infinity) = 0x020113134b21797f # made up
+
+# `isequal` implies equal hashes, so the infinities have to hash like the float
+# infinities they compare equal to. The interface requires implementing `hash(x, h::UInt)`.
+
+Base.hash(::Infinity, h::UInt)::UInt = hash(Inf, h)
+Base.hash(::PositiveInfinity, h::UInt)::UInt = hash(Inf, h)
+Base.hash(::NegativeInfinity, h::UInt)::UInt = hash(-Inf, h)
+
+# Equality of ComplexInfinity is equality of the angle, hence so is the hash.
+function Base.hash(x::ComplexInfinity, h::UInt)::UInt
+    θ = angle(x)
+    θ == angle(PositiveInfinity()) && return hash(Inf, h)
+    θ == angle(NegativeInfinity()) && return hash(-Inf, h)
+    hash(ComplexInfinity, hash(θ, h))
+end
 
 
 include("cardinality.jl")

--- a/src/cardinality.jl
+++ b/src/cardinality.jl
@@ -72,8 +72,9 @@ Base.Checked.checked_mul(::InfiniteCardinal{0}, ::InfiniteCardinal{0}) = ℵ₀
 ##
 # hash
 ##
-Base.hash(::InfiniteCardinal{0}) = 0x775431eef01bca90 # made up
-Base.hash(::InfiniteCardinal{1}) = 0x55437c69b794f8ce # made up
+# `isequal(a, b)` implies `hash(a) == hash(b)` so conform as ℵ₀ is `isequal` to `Inf`.
+Base.hash(::InfiniteCardinal{0}, h::UInt)::UInt = hash(Inf, h)
+Base.hash(x::InfiniteCardinal, h::UInt)::UInt = hash(typeof(x), h)
 
 
 # avoid stack overflow

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -320,6 +320,25 @@ using Aqua
         @test 2 ∉ s
     end
 
+    @testset "hash" begin
+        infinities = (∞, +∞, -∞, Inf, -Inf, Inf32, Inf16, big(Inf),
+                      InfiniteCardinal{0}(), ComplexInfinity(false),
+                      ComplexInfinity(true), ComplexInfinity(0.1))
+
+        # isequal must imply equal hashes
+        for a in infinities, b in infinities
+            isequal(a, b) && @test hash(a) == hash(b)
+        end
+
+        @test hash(+∞) ≠ hash(-∞)
+        @test hash(ℵ₀) ≠ hash(ℵ₁)
+
+        for x in (infinities..., ℵ₁)
+            @test hash(x, UInt(1)) isa UInt
+            @test hash((x,)) isa UInt
+        end
+    end
+
     @testset "Base.literal_pow" begin
         @test Base.literal_pow(^, ℵ₀, Val(0)) ≡ ℵ₀^0 ≡ 1
         @test Base.literal_pow(^, ℵ₀, Val(1)) ≡ ℵ₀^1 ≡ ℵ₀


### PR DESCRIPTION
:robot:
Base's hashing dispatches on `hash(x, h::UInt)`, so the one-argument methods defined here were never called; `hash(::Infinity, ::UInt)` resolved to Base's `hash(::Real, ::UInt)`. That made `hash(x)` throw a `MethodError` for `PositiveInfinity` and `NegativeInfinity`, and silently broke the `isequal`/`hash` contract for the rest: `isequal(∞, Inf)` holds but `hash(∞) != hash(Inf)`, and likewise for `InfiniteCardinal{0}()`. Seeded and nested uses such as `hash(∞, UInt(1))` or `hash((∞,))` failed outright.

Define the two-argument method for each type, forwarding to the float infinity it compares equal to. `ComplexInfinity` is keyed on the angle, matching how `==` compares it. `InfiniteCardinal{N}` for `N != 0` equals no float infinity and keeps a separate hash.