### PR TITLE
Fix comparisons against infinities, and add `isinf(x, y)`

### DIFF
--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -7,7 +7,7 @@ end
 ComplexInfinity{T}(x::ComplexInfinity{T}) where T<:Real = x
 
 for Typ in (Rational, BigInt, BigFloat)
-    for (op, fop) in ((:<, :isless), (:≤, :_le))
+    for (op, fop) in ((:<, :_lt), (:≤, :_le))
         @eval $op(x::InfiniteCardinal, y::$Typ) = $fop(x, y)
         @eval $op(x::$Typ, y::InfiniteCardinal) = $fop(x, y)
     end

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -13,6 +13,9 @@ of a type outside the numeric hierarchy included.
 """
 isinf(_, ::AllInfinities) = false
 isinf(x::Number, y::AllInfinities) = isinf(x) && _angle(x) == angle(y)
+# On the real line the direction is a comparison against zero.
+# `signbit(y)` is constant, so the branch folds away and the check becomes a single instruction.
+isinf(x::Real, y::AllRealInfinities) = isinf(x) && (signbit(y) ? x < zero(x) : x > zero(x))
 
 # ==
 @inline _eq(x, y::InfiniteCardinal) = x == ∞ && y == ℵ₀

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -9,27 +9,32 @@
 ==(x::AllInfinities, y::AllInfinities) = _infeq(x, y)
 
 # isless
+# `isless` is the sort order. `NaN` sorts after every other value, infinities included.
 isless(x::AllRealInfinities, y::AllRealInfinities) = signbit(x) && !signbit(y)
 @generated isless(::InfiniteCardinal{N}, ::InfiniteCardinal{M}) where {N,M} = :($(isless(N, M)))
+# The leading `signbit` call discards its result. It is there to reject a non-real `Number`.
 for Typ in (Number, Real, AbstractFloat)
     @eval begin
-        isless(x::AllRealInfinities, y::$Typ) = (signbit(y); signbit(x) && y ≠ -∞)
-        isless(x::$Typ, y::AllRealInfinities) = (signbit(x); !signbit(y) && x ≠ ∞)
+        isless(x::AllRealInfinities, y::$Typ) = (signbit(y); isnan(y) || signbit(x) && y ≠ -∞)
+        isless(x::$Typ, y::AllRealInfinities) = (signbit(x); !isnan(x) && !signbit(y) && x ≠ ∞)
     end
 end
 for Typ in (Number, Real, AbstractFloat, AllRealInfinities)
     @eval begin
-        isless(::InfiniteCardinal, x::$Typ) = false
+        isless(::InfiniteCardinal, x::$Typ) = isnan(x)
         isless(x::$Typ, y::InfiniteCardinal) = isless(x, ∞) || isless(ℵ₀, y)
     end
 end
 isless(::InfiniteCardinal{0}, ::InfiniteCardinal{0}) = false
 
 # minmax, <, ≤
-@inline _max(x, y) = ifelse(y < x, x, y)
-@inline _min(x, y) = ifelse(y < x, y, x)
+# `<`, `max` and `min` use the numeric comparison, not the sort order. They differ at `NaN`:
+# it compares false against everything and propagates through `max` and `min`.
+@inline _lt(x, y) = !isnan(x) && !isnan(y) && isless(x, y)
 @inline _le(x, y) = x < y || x == y
-for (op, fop) in ((:max, :_max), (:min, :_min), (:<, :isless), (:≤, :_le))
+@inline _max(x, y) = isnan(x) ? x : isnan(y) ? y : ifelse(_lt(y, x), x, y)
+@inline _min(x, y) = isnan(x) ? x : isnan(y) ? y : ifelse(_lt(y, x), y, x)
+for (op, fop) in ((:max, :_max), (:min, :_min), (:<, :_lt), (:≤, :_le))
     for Typ in (Real, )
         @eval begin
             $op(x::AllInfinities, y::$Typ) = $fop(x, y)
@@ -38,4 +43,3 @@ for (op, fop) in ((:max, :_max), (:min, :_min), (:<, :isless), (:≤, :_le))
     end
     @eval $op(x::AllInfinities, y::AllInfinities) = $fop(x, y)
 end
-        

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -3,9 +3,20 @@
 _angle(x::Real) = angle(RealInfinity(signbit(x)))
 _angle(x::Number) = angle(x)
 
+# isinf
+"""
+    isinf(x, y)
+
+test whether `x` is an infinity pointing in the same direction as the infinity `y`,
+e.g. `isinf(-Inf, -∞)`. Everything that is not such an infinity gives `false`, a value
+of a type outside the numeric hierarchy included.
+"""
+isinf(_, ::AllInfinities) = false
+isinf(x::Number, y::AllInfinities) = isinf(x) && _angle(x) == angle(y)
+
 # ==
 @inline _eq(x, y::InfiniteCardinal) = x == ∞ && y == ℵ₀
-@inline _eq(x, y::AllInfinities) = isinf(x) && angle(y) == _angle(x)
+@inline _eq(x, y::AllInfinities) = isinf(x, y)
 @inline _infeq(x, y) = _eq(x, y)
 @inline _infeq(x::InfiniteCardinal, y) = _eq(y, x)
 @inline _infeq(x::InfiniteCardinal, y::InfiniteCardinal) = !(x<y) & !(y<x)

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -5,21 +5,21 @@ _angle(x::Number) = angle(x)
 
 # isinf
 """
-    isinf(x, y)
+    _isinf(x, y)
 
 test whether `x` is an infinity pointing in the same direction as the infinity `y`,
-e.g. `isinf(-Inf, -∞)`. Everything that is not such an infinity gives `false`, a value
+e.g. `_isinf(-Inf, -∞)`. Everything that is not such an infinity gives `false`, a value
 of a type outside the numeric hierarchy included.
 """
-isinf(_, ::AllInfinities) = false
-isinf(x::Number, y::AllInfinities) = isinf(x) && _angle(x) == angle(y)
+_isinf(_, ::AllInfinities) = false
+_isinf(x::Number, y::AllInfinities) = isinf(x) && _angle(x) == angle(y)
 # On the real line the direction is a comparison against zero.
 # `signbit(y)` is constant, so the branch folds away and the check becomes a single instruction.
-isinf(x::Real, y::AllRealInfinities) = isinf(x) && (signbit(y) ? x < zero(x) : x > zero(x))
+_isinf(x::Real, y::AllRealInfinities) = isinf(x) && (signbit(y) ? x < zero(x) : x > zero(x))
 
 # ==
 @inline _eq(x, y::InfiniteCardinal) = x == ∞ && y == ℵ₀
-@inline _eq(x, y::AllInfinities) = isinf(x, y)
+@inline _eq(x, y::AllInfinities) = _isinf(x, y)
 @inline _infeq(x, y) = _eq(x, y)
 @inline _infeq(x::InfiniteCardinal, y) = _eq(y, x)
 @inline _infeq(x::InfiniteCardinal, y::InfiniteCardinal) = !(x<y) & !(y<x)

--- a/src/compare.jl
+++ b/src/compare.jl
@@ -1,6 +1,11 @@
+# The direction of an infinity, as a precision-independent angle.
+# `angle` evaluates π in the precision of its argument, so `angle(-Inf32) ≠ angle(-Inf)`.
+_angle(x::Real) = angle(RealInfinity(signbit(x)))
+_angle(x::Number) = angle(x)
+
 # ==
 @inline _eq(x, y::InfiniteCardinal) = x == ∞ && y == ℵ₀
-@inline _eq(x, y::AllInfinities) = isinf(x) && angle(y) == angle(x)
+@inline _eq(x, y::AllInfinities) = isinf(x) && angle(y) == _angle(x)
 @inline _infeq(x, y) = _eq(x, y)
 @inline _infeq(x::InfiniteCardinal, y) = _eq(y, x)
 @inline _infeq(x::InfiniteCardinal, y::InfiniteCardinal) = !(x<y) & !(y<x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Infinities, Base64, Test
-import Infinities: Infinity, AllInfinities
+import Infinities: Infinity, AllInfinities, _isinf
 
 using Aqua, JET
 
@@ -407,7 +407,7 @@ Base.iterate(s::CharString, i::Integer=1) = i ≤ length(s.chars) ? (s.chars[i],
         end
     end
 
-    @testset "isinf(x, y)" begin
+    @testset "_isinf(x, y)" begin
         # ℵ₁ points in the same direction as ∞, even though `ℵ₁ == ∞` is false
         positive = (∞, +∞, ℵ₀, ℵ₁, ComplexInfinity(), Inf, Inf32, Inf16, big(Inf))
         negative = (-∞, -ComplexInfinity(), -Inf, -Inf32, -Inf16, -big(Inf))
@@ -418,14 +418,14 @@ Base.iterate(s::CharString, i::Integer=1) = i ≤ length(s.chars) ? (s.chars[i],
         for xs in (positive, negative, imaginary, others), ys in (positive, negative, imaginary)
             for x in xs, y in ys
                 y isa AllInfinities || continue # only our own infinities are admissible as a reference
-                @test isinf(x, y) == (xs === ys)
+                @test _isinf(x, y) == (xs === ys)
                 # `==` asks the narrower question, and `ℵ₁` is the whole of the difference
                 if x !== ℵ₁ && y !== ℵ₁
-                    @test isinf(x, y) == (x == y)
+                    @test _isinf(x, y) == (x == y)
                 end
             end
         end
-        @test isinf(ℵ₁, ∞) && isinf(∞, ℵ₁) && isinf(Inf, ℵ₁) && isinf(ℵ₁, ℵ₀)
+        @test _isinf(ℵ₁, ∞) && _isinf(∞, ℵ₁) && _isinf(Inf, ℵ₁) && _isinf(ℵ₁, ℵ₀)
         @test ℵ₁ ≠ ∞ && ∞ ≠ ℵ₁ && Inf ≠ ℵ₁ && ℵ₁ ≠ ℵ₀
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Infinities, Base64, Test
-import Infinities: Infinity
+import Infinities: Infinity, AllInfinities
 
 using Aqua, JET
 
@@ -405,6 +405,28 @@ Base.iterate(s::CharString, i::Integer=1) = i ≤ length(s.chars) ? (s.chars[i],
                 @test T(Inf) ≠ inf
             end
         end
+    end
+
+    @testset "isinf(x, y)" begin
+        # ℵ₁ points in the same direction as ∞, even though `ℵ₁ == ∞` is false
+        positive = (∞, +∞, ℵ₀, ℵ₁, ComplexInfinity(), Inf, Inf32, Inf16, big(Inf))
+        negative = (-∞, -ComplexInfinity(), -Inf, -Inf32, -Inf16, -big(Inf))
+        imaginary = (ComplexInfinity(0.5), complex(0.0, Inf))
+        others = (0, 1.5, -2, -1.5, 0.0, -0.0, NaN, NaN32, prevfloat(Inf), nextfloat(-Inf),
+                  nextfloat(0.0), prevfloat(-0.0), "∞", "-∞")
+
+        for xs in (positive, negative, imaginary, others), ys in (positive, negative, imaginary)
+            for x in xs, y in ys
+                y isa AllInfinities || continue # only our own infinities are admissible as a reference
+                @test isinf(x, y) == (xs === ys)
+                # `==` asks the narrower question, and `ℵ₁` is the whole of the difference
+                if x !== ℵ₁ && y !== ℵ₁
+                    @test isinf(x, y) == (x == y)
+                end
+            end
+        end
+        @test isinf(ℵ₁, ∞) && isinf(∞, ℵ₁) && isinf(Inf, ℵ₁) && isinf(ℵ₁, ℵ₀)
+        @test ℵ₁ ≠ ∞ && ∞ ≠ ℵ₁ && Inf ≠ ℵ₁ && ℵ₁ ≠ ℵ₀
     end
 
     @testset "NaN" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -394,6 +394,37 @@ Base.iterate(s::CharString, i::Integer=1) = i ≤ length(s.chars) ? (s.chars[i],
         @test zero(exp(0.1im)∞) ≡ zero(ComplexInfinity) ≡ 0.0+0.0im
     end
 
+    @testset "NaN" begin
+        for nan in (NaN, NaN32, NaN16, big(NaN)), inf in (∞, +∞, -∞, ℵ₀)
+            # a numeric comparison is false in every direction
+            for op in (<, ≤, >, ≥, ==)
+                @test !op(nan, inf) && !op(inf, nan)
+            end
+
+            # the sort order puts `NaN` after every value, an infinity included
+            @test isless(inf, nan) && !isless(nan, inf)
+            @test (isless(nan, inf), isless(inf, nan), isequal(nan, inf)) |> count == 1
+
+            # `max` and `min` propagate `NaN`, as they do over the floats alone
+            @test isnan(max(nan, inf)) && isnan(max(inf, nan))
+            @test isnan(min(nan, inf)) && isnan(min(inf, nan))
+        end
+        sorted = sort([∞, NaN, 1.0, -∞])
+        @test sorted[1] === -∞ && sorted[2] === 1.0 && sorted[3] === ∞ && isnan(sorted[4])
+    end
+
+    @testset "ordinary values" begin
+        for inf in (∞, +∞, ℵ₀)
+            @test 1.0 < inf && !(inf < 1.0) && 1.0 ≤ inf && inf ≥ 1.0
+            @test isless(1.0, inf) && !isless(inf, 1.0)
+            @test max(1.0, inf) === max(inf, 1.0) === inf
+            @test min(1.0, inf) === min(inf, 1.0) === 1.0
+        end
+        @test -∞ < 1 < ∞ && -∞ ≤ -∞ && ∞ ≤ ∞
+        @test !(Inf < ∞) && !(∞ < Inf) && Inf ≤ ∞
+        @test max(-∞, ∞) === ∞ && min(-∞, ∞) === -∞
+    end
+
     @testset "parsing" begin
         @test tryparse(NegativeInfinity, "-∞") == NegativeInfinity()
         @test tryparse(NegativeInfinity, " - ∞ ") == NegativeInfinity()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -336,7 +336,7 @@ Base.iterate(s::CharString, i::Integer=1) = i ≤ length(s.chars) ? (s.chars[i],
     end
 
     @testset "hash" begin
-        infinities = (∞, +∞, -∞, Inf, -Inf, Inf32, Inf16, big(Inf),
+        infinities = (∞, +∞, -∞, Inf, -Inf, Inf32, -Inf32, Inf16, -Inf16, big(Inf), -big(Inf),
                       InfiniteCardinal{0}(), ComplexInfinity(false),
                       ComplexInfinity(true), ComplexInfinity(0.1))
 
@@ -392,6 +392,19 @@ Base.iterate(s::CharString, i::Integer=1) = i ≤ length(s.chars) ? (s.chars[i],
         @test zero(ℵ₀) ≡ zero(∞) ≡ zero(Infinity) ≡ zero(InfiniteCardinal{0}) ≡ 0
         @test zero(-∞) ≡ zero(RealInfinity) ≡ 0.0
         @test zero(exp(0.1im)∞) ≡ zero(ComplexInfinity) ≡ 0.0+0.0im
+    end
+
+    @testset "float precisions" begin
+        for T in (Float16, Float32, Float64, BigFloat)
+            for inf in (∞, +∞, ComplexInfinity(), ℵ₀)
+                @test T(Inf) == inf == T(Inf)
+                @test T(-Inf) ≠ inf
+            end
+            for inf in (-∞, -ComplexInfinity())
+                @test T(-Inf) == inf == T(-Inf)
+                @test T(Inf) ≠ inf
+            end
+        end
     end
 
     @testset "NaN" begin


### PR DESCRIPTION
This is a collection of related commits which to some extend build on each other, so separating them in different PRs would be possible, but probably not simpler.

I recommend reviewing this commit by commit.

1. `NaN` compared as an ordinary value against an infinity. It now sorts after every value while `<`, `max` and `min` treat it exactly as they do against `Inf`.
2. `angle` evaluates π in the precision of its argument, so `-Inf32 == -∞`, `-Inf16 == -∞` and `-big(Inf) == -∞` were all false. Equality now compares the canonical angle that `hash` already uses.
3. `isinf(x, y)` answers the question whether `x` is an infinity pointing the way `y` does, and `==` is expressed through it so the two cannot drift apart.
4. the direction of a real is answered by a comparison against zero, which fuses with `isinf` and shortens the check from seven instructions to two without changing the answer.