### PR TITLE
Fix NaN arithmetic

### DIFF
--- a/src/Infinities.jl
+++ b/src/Infinities.jl
@@ -107,11 +107,9 @@ ComplexInfinity{T}(::Infinity) where T<:Real = ComplexInfinity{T}()
 ComplexInfinity(::Infinity) = ComplexInfinity()
 ComplexInfinity{T}(x::RealInfinity) where T<:Real = ComplexInfinity{T}(signbit(x))
 ComplexInfinity(x::RealInfinity) = ComplexInfinity(signbit(x))
-ComplexInfinity{T}(x::ComplexInfinity) where T<:Real = ComplexInfinity(T(signbit(x))) # ambiguity fix
+ComplexInfinity{T}(x::ComplexInfinity) where T<:Real = ComplexInfinity(T(x.signbit)) # ambiguity fix
 
-signbit(y::ComplexInfinity{Bool}) = y.signbit
-signbit(y::ComplexInfinity{<:Integer}) = !(mod(y.signbit,2) == 0)
-signbit(y::ComplexInfinity) = y.signbit
+signbit(y::ComplexInfinity) = mod(y.signbit, 2) == 1
 
 convert(::Type{ComplexInfinity{T}}, ::Infinity) where T = ComplexInfinity{T}()
 convert(::Type{ComplexInfinity}, ::Infinity) = ComplexInfinity()

--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -49,7 +49,8 @@
 # multiplication
 
 @inline _sb(x) = signbit(x)
-@inline _sb(x::Complex) = angle(x)/π # overloading `signbit` causes type piracy 
+@inline _sb(x::Complex) = angle(x)/π # overloading `signbit` causes type piracy
+@inline _sb(x::ComplexInfinity) = x.signbit # the whole angle, not just its sign
 
 @inline __mul(x, y::AllInfinities) = RealInfinity(_sb(x) ⊻ _sb(y))
 @inline __mul(x, y::ComplexInfinity) = ComplexInfinity(_sb(x) + _sb(y))

--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -30,7 +30,8 @@
 @inline __add(x, y::AllInfinities) = isinf(x) ? _infadd(toinf(x), y) : y
 @inline __add(x::Integer, y::InfiniteCardinal) = max(x, y)
 
-@inline _add(x, y) = __add(infpromote(x, y)...)
+# A `NaN` argument is returned unchanged, as it is over the floats. Types with no `NaN` fold the test away.
+@inline _add(x, y) = isnan(x) ? x : __add(infpromote(x, y)...)
 
 +(x::Number, y::AllInfinities) = _add(x, y)
 +(x::AllInfinities, y::Number) = _add(y, x)
@@ -56,7 +57,11 @@
 @inline __mul(x::Complex, y::ComplexInfinity{Bool}) = ComplexInfinity(_sb(x) + _sb(y))
 @inline __mul(x::Integer, y::InfiniteCardinal) = x > 0 ? y : throw(ArgumentError("Cannot multiply $x * $y"))
 
-@inline _mul(x, y) = iszero(x) ? throw(ArgumentError("Cannot multiply $x * $y")) : __mul(infpromote(x, y)...)
+@inline function _mul(x, y)
+    isnan(x) && return x
+    iszero(x) && throw(ArgumentError("Cannot multiply $x * $y"))
+    __mul(infpromote(x, y)...)
+end
 
 *(x::Number, y::AllInfinities) = _mul(x, y)
 *(x::AllInfinities, y::Number) = _mul(y, x)
@@ -71,6 +76,7 @@
 
 # mod
 @inline function _mod(x::Real, y::IntegerInfinities)
+    isnan(x) && return x
     signbit(x) == signbit(y) || throw(ArgumentError("mod($x,$y) is unbounded"))
     x
 end
@@ -79,14 +85,14 @@ mod(::IntegerInfinities, ::Real) = NotANumber()
 mod(::IntegerInfinities, ::IntegerInfinities) = NotANumber()
 
 # fld, cld, div
-_divinf(T) = zero(T)
-_fldinf(x) = signbit(x) ? -one(x) : zero(x)
-_cldinf(x) = signbit(x) ? zero(x) : one(x)
-div(::T, ::IntegerInfinities) where T <: Real = _divinf(T)
+_divinf(x) = isnan(x) ? x : zero(x)
+_fldinf(x) = isnan(x) ? x : signbit(x) ? -one(x) : zero(x)
+_cldinf(x) = isnan(x) ? x : signbit(x) ? zero(x) : one(x)
+div(x::Real, ::IntegerInfinities) = _divinf(x)
 fld(x::Real, ::IntegerInfinities) = _fldinf(x)
 cld(x::Real, ::IntegerInfinities) = _cldinf(x)
 
-_inffcd(x, y) = signbit(y) ? -x : x
+_inffcd(x, y) = isnan(y) ? y : signbit(y) ? -x : x
 for OP in (:fld,:cld,:div)
     @eval begin
         $OP(x::IntegerInfinities, y::Real) = _inffcd(x, y)
@@ -97,8 +103,9 @@ end
 # power
 # Although the base implementation can cover these cases, it can change overtime and yield inconsistent results.
 # ref: https://github.com/JuliaMath/Infinities.jl/actions/runs/19993302836/
-_infpow(::PositiveInfinity, p) = ifelse(iszero(p), one(p), ifelse(p > 0, +∞, +zero(p)))
+_infpow(::PositiveInfinity, p) = isnan(p) ? p : ifelse(iszero(p), one(p), ifelse(p > 0, +∞, +zero(p)))
 function _infpow(x::NegativeInfinity, p)
+    isnan(p) && return p
     !isinteger(p) && throw(Base.Math.throw_exp_domainerror(x))
     iszero(p) && return one(p)
     isodd(p) && return ifelse(p > 0, -∞, -zero(p))

--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -6,6 +6,9 @@
 @inline infpromote(x::RealInfinity, y::Union{Integer, Rational}) = (x, float(y))
 @inline infpromote(x::Union{Integer, Rational}, y::RealInfinity) = (float(x), y)
 @inline infpromote(x::RealInfinity, ::InfiniteCardinal) = (x, ∞)
+# `Base` promotes every `Real` to `BigFloat`, which would convert the infinity away.
+@inline infpromote(x::BigFloat, y::Union{Infinity,RealInfinity}) = (x, y)
+@inline infpromote(x::Union{Infinity,RealInfinity}, y::BigFloat) = (x, y)
 
 
 # sign

--- a/src/ambiguities.jl
+++ b/src/ambiguities.jl
@@ -35,7 +35,7 @@ for Typ in (Rational, )
     for op in (:fld, :cld, :div)
         @eval $op(x::InfiniteCardinal, y::$Typ) = _inffcd(x, y)
     end
-    @eval div(::T, ::IntegerInfinities) where T <: $Typ = _divinf(T)
+    @eval div(x::$Typ, ::IntegerInfinities) = _divinf(x)
     @eval fld(x::$Typ, ::IntegerInfinities) = _fldinf(x)
     @eval cld(x::$Typ, ::IntegerInfinities) = _cldinf(x)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -450,6 +450,20 @@ Base.iterate(s::CharString, i::Integer=1) = i ≤ length(s.chars) ? (s.chars[i],
         @test sorted[1] === -∞ && sorted[2] === 1.0 && sorted[3] === ∞ && isnan(sorted[4])
     end
 
+    @testset "NaN arithmetic" begin
+        for nan in (NaN, NaN32, NaN16, big(NaN)),
+            inf in (∞, +∞, -∞, ℵ₀, ComplexInfinity(), -ComplexInfinity())
+
+            for op in (+, -, *, div, fld, cld)
+                @test isnan(op(nan, inf)) && isnan(op(inf, nan))
+            end
+            @test isnan(mod(nan, inf)) # the other direction is `NotANumber` for every argument
+        end
+        for nan in (NaN, NaN32, NaN16, big(NaN)), inf in (+∞, -∞)
+            @test isnan(inf^nan)
+        end
+    end
+
     @testset "ordinary values" begin
         for inf in (∞, +∞, ℵ₀)
             @test 1.0 < inf && !(inf < 1.0) && 1.0 ≤ inf && inf ≥ 1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -479,6 +479,20 @@ Base.iterate(s::CharString, i::Integer=1) = i ≤ length(s.chars) ? (s.chars[i],
         @test max(-∞, ∞) === ∞ && min(-∞, ∞) === -∞
     end
 
+    @testset "against the floats" begin
+        values = (0, 1, -2, 1.5, -1.5, 0.0, -0.0, NaN, NaN32, Inf, -Inf,
+                  prevfloat(Inf), nextfloat(-Inf), nextfloat(0.0))
+        for x in values, (inf, flt) in ((∞, Inf), (+∞, Inf), (-∞, -Inf), (ℵ₀, Inf))
+            for op in (<, ≤, >, ≥, ==, isless, isequal)
+                @test op(x, inf) == op(x, flt)
+                @test op(inf, x) == op(flt, x)
+            end
+            for op in (max, min)
+                @test isequal(op(x, inf), op(x, flt)) && isequal(op(inf, x), op(flt, x))
+            end
+        end
+    end
+
     @testset "parsing" begin
         @test tryparse(NegativeInfinity, "-∞") == NegativeInfinity()
         @test tryparse(NegativeInfinity, " - ∞ ") == NegativeInfinity()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -404,6 +404,8 @@ Base.iterate(s::CharString, i::Integer=1) = i ≤ length(s.chars) ? (s.chars[i],
                 @test T(-Inf) == inf == T(-Inf)
                 @test T(Inf) ≠ inf
             end
+            @test T(2) + ∞ ≡ ∞ + T(2) ≡ ∞
+            @test T(2) * +∞ ≡ (+∞)^T(2) ≡ +∞
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -326,6 +326,9 @@ Base.iterate(s::CharString, i::Integer=1) = i ≤ length(s.chars) ? (s.chars[i],
 
         @test signbit(ComplexInfinity(3))
         @test !signbit(ComplexInfinity(100))
+        # `signbit` returns a `Bool` for every angle, as it does over the reals
+        @test signbit(ComplexInfinity(1.0)) === signbit(-ComplexInfinity()) === true
+        @test signbit(ComplexInfinity(0.5)) === signbit(ComplexInfinity()) === false
     end
 
     @testset "Set" begin


### PR DESCRIPTION
~~Builds on the `infinity_direction` branch, so we can rebase the current PR on `master` once #80 has landed to reduce the overall diff size (we both have the permissions).~~ I recommend to review again commit-by-commit. The most recent 4 commits are new.

1. `Base` promotes every `Real` to `BigFloat`, so `Base._promote` converted the infinity away and `big(2.0) + ∞`, `big(2.0) * ∞` and `(+∞)^big(2.0)` were all `MethodError`s, which also made the `NaN` work below untestable at that precision.
2. `NaN + ∞` gave `∞`, `NaN * ∞` gave `+∞`, `div(NaN, ∞)` gave `0.0` and `(+∞)^NaN` gave `0.0`, so a `NaN` marking a failed computation silently became a plausible infinity; every entry point now returns its `NaN` argument unchanged, precision included.
3. `signbit(ComplexInfinity(0.5))` returned the field itself, `0.5`, so any caller branching on it hit a `TypeError`. The three methods are replaced by one correct method.
4. Add tests for such cases  to avoid these kind of errors in the future.

This PR changes inference, but it was necessary to have a correct result:
- `x::Float64 + ∞` now infers `Union{Float64, Infinity}` rather than `Infinity` (but no allocations)
- `x::Int + ∞` is unchanged because `isnan` folds away for types that have no `NaN`.