### PR TITLE
Run JET over the package in the test suite

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,15 @@ version = "0.1.12"
 [compat]
 Aqua = "0.8"
 Base64 = "1"
+JET = "0.9, 0.10, 0.11, 0.12"
 Test = "1"
 julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Base64", "Test"]
+test = ["Aqua", "Base64", "JET", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Infinities, Base64, Test
 import Infinities: Infinity
 
-using Aqua
+using Aqua, JET
 
 "An `AbstractString` indexed by character position, so that byte arithmetic on indices is invalid."
 struct CharString <: AbstractString
@@ -447,4 +447,5 @@ include("test_ambiguity.jl")
 
 @testset "Project quality" begin
     Aqua.test_all(Infinities)
+    test_package(Infinities)
 end


### PR DESCRIPTION
Introducing JET testing and not finding a single issue – great!

The compat range covers every version in the CI matrix: JET 0.9.18 resolves on the LTS, 0.12.1 on the current release and on the prerelease.